### PR TITLE
Making doParse protected (for issue #8)

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -103,7 +103,7 @@ class Parser
      *
      * @return array The .env contents
      */
-    private function doParse($content)
+    protected function doParse($content)
     {
         $raw_lines = array_filter($this->makeLines($content), 'strlen');
 


### PR DESCRIPTION
This changes the visibility of the `doParse` method over from `private` to `protected` to make it more extensible.