### PR TITLE
allow for the pull of a single value using getContent on the Parser class

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -234,8 +234,12 @@ class Parser
      *
      * @return array The .env contents
      */
-    public function getContent()
+    public function getContent($keyName = null)
     {
-        return $this->lines;
+		if ($keyName !== null) {
+			return (array_key_exists($keyName, $this->lines)) ? $this->lines[$keyName] : null;
+		} else {
+			return $this->lines;
+		}
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -236,10 +236,9 @@ class Parser
      */
     public function getContent($keyName = null)
     {
-		if ($keyName !== null) {
+		if (!is_null($keyName)) {
 			return (array_key_exists($keyName, $this->lines)) ? $this->lines[$keyName] : null;
-		} else {
-			return $this->lines;
 		}
+        return $this->lines;
     }
 }


### PR DESCRIPTION
This PR updates the `Parser` class to allow for pulling just one value from the `getContent` method (if it exists). Otherwise, it will just return the full set as before.