### PR TITLE
Fix skiping lines without key/value assignement.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -143,7 +143,9 @@ class Parser
         foreach ($raw_lines as $raw_line) {
             $this->line_num++;
 
-            if ($this->string_helper->startsWith('#', $raw_line) || !$raw_line) {
+            $line = trim($raw_line);
+
+            if ($this->string_helper->startsWith('#', $line) || !$line) {
                 continue;
             }
 

--- a/tests/mocks/comments.env
+++ b/tests/mocks/comments.env
@@ -2,6 +2,7 @@
 TK1 = value # nor should this
 TK2 = value #this either
 TK3 = value#thisisnotacomment
-TK4 = #or this
+TK4 = #next line consists only of spaces
+ 
 # or this TK4 = "value"
-            #TK5 = VALUE
+            #this line consists of tabs and comment, but the comment doesn't contain key/value assignement


### PR DESCRIPTION
Fix in 2 cases:
1. Line contains only spaces.
2. Line contains spaces and comment and to the right of '#' sign there is no key/value assignement.